### PR TITLE
fix: add basename to React Router for GitHub Pages deployment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,22 @@ import ResumePage from './components/ResumePage'
 import TablePage from './components/TablePage'
 
 /**
+ * Get the base name for React Router based on environment
+ * In production (GitHub Pages), use the repository name as basename
+ */
+const getBasename = () => {
+  if (import.meta.env.PROD && import.meta.env.VITE_BASE_URL) {
+    return `/${import.meta.env.VITE_BASE_URL}`
+  }
+  return '/'
+}
+
+/**
  * Main App component with React Router setup
  */
 function App() {
   return (
-    <Router>
+    <Router basename={getBasename()}>
       <Routes>
         <Route path='/' element={<ResumePage />} />
         <Route path='/table' element={<TablePage />} />


### PR DESCRIPTION
Fixes the routing issue on GitHub Pages by adding basename configuration to React Router.\n\nThe error 'No routes matched location "/resume/"' was caused by React Router not being aware of the GitHub Pages base path. This PR adds a getBasename() function that dynamically sets the basename based on the VITE_BASE_URL environment variable in production.\n\nChanges:\n- Added getBasename() function to determine the correct basename\n- Updated Router component to use the basename prop\n- Ensures compatibility with both local development and GitHub Pages deployment