### PR TITLE
feat: add OpenAI API key environment variable to GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           # Add any environment variables needed for build
           VITE_BASE_URL: ${{ github.event.repository.name }}
+          VITE_OPENAI_API_KEY: ${{ secrets.VITE_OPENAI_API_KEY }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
Adds VITE_OPENAI_API_KEY environment variable to the GitHub Pages deployment workflow.\n\nThis change enables the ChatBot component to access the OpenAI API key during the build process on GitHub Pages.\n\n**Changes:**\n- Added VITE_OPENAI_API_KEY environment variable to the build step in deploy.yml\n- The API key will be sourced from GitHub repository secrets\n\n**Next Steps:**\nAfter merging this PR, you need to add the OpenAI API key as a repository secret:\n1. Go to Settings → Secrets and variables → Actions\n2. Add a new repository secret named \n3. Set the value to your OpenAI API key\n\nThis will enable the ChatBot functionality on the deployed GitHub Pages site.